### PR TITLE
NDEV-3110: Update Solana to v1.18.18

### DIFF
--- a/common/neon_rpc/api.py
+++ b/common/neon_rpc/api.py
@@ -19,6 +19,7 @@ from ..solana.pubkey import SolPubKeyField, SolPubKey
 from ..solana.transaction import SolTx
 from ..utils.cached import cached_property, cached_method
 from ..utils.format import bytes_to_hex
+from ..utils.json_logger import get_ctx
 from ..utils.pydantic import HexUIntField, BytesField, DecIntField, BaseModel as _BaseModel
 
 _LOG = logging.getLogger(__name__)
@@ -80,7 +81,7 @@ class NeonAccountListRequest(BaseModel):
 
     @classmethod
     def from_raw(cls, account_list: Sequence[NeonAccount], slot: int | None) -> Self:
-        return cls(account_list=tuple([_AccountModel.from_raw(a) for a in account_list]), slot=slot)
+        return cls(account_list=tuple([_AccountModel.from_raw(a) for a in account_list]), slot=slot, id=get_ctx())
 
 
 class NeonAccountStatus(StrEnum):
@@ -391,7 +392,7 @@ class HolderAccountRequest(BaseModel):
 
     @classmethod
     def from_raw(cls, pubkey: SolPubKey) -> Self:
-        return cls(pubkey=pubkey)
+        return cls(pubkey=pubkey, id=get_ctx())
 
 
 class HolderAccountStatus(StrEnum):

--- a/common/neon_rpc/client.py
+++ b/common/neon_rpc/client.py
@@ -46,7 +46,7 @@ from ..solana.pubkey import SolPubKey
 from ..solana.transaction import SolTx
 from ..solana_rpc.client import SolClient
 from ..utils.cached import cached_method, ttl_cached_method
-from ..utils.json_logger import log_msg
+from ..utils.json_logger import log_msg, get_ctx
 from ..utils.pydantic import BaseModel
 
 _LOG = logging.getLogger(__name__)
@@ -151,12 +151,12 @@ class CoreApiClient(SimpleAppDataClient):
         return acct.state_tx_cnt
 
     async def get_neon_contract(self, account: NeonAccount, block: NeonBlockHdrModel | None) -> NeonContractModel:
-        req = NeonContractRequest(contract=account.eth_address, slot=self._get_slot(block))
+        req = NeonContractRequest(contract=account.eth_address, slot=self._get_slot(block), id=get_ctx())
         resp: CoreApiResp = await self._call_method(self._get_neon_contract, req)
         return NeonContractModel.from_dict(resp.value[0], account=account)
 
     async def get_storage_at(self, contract: EthAddress, index: int, block: NeonBlockHdrModel | None) -> EthHash32:
-        req = NeonStorageAtRequest(contract=contract, index=index, slot=self._get_slot(block))
+        req = NeonStorageAtRequest(contract=contract, index=index, slot=self._get_slot(block), id=get_ctx())
         resp: CoreApiResp = await self._call_method(self._get_storage_at, req)
         return EthHash32.from_raw(bytes(resp.value))
 
@@ -231,6 +231,7 @@ class CoreApiClient(SimpleAppDataClient):
             preload_sol_address_list=list(preload_sol_address_list),
             sol_account_dict=emul_sol_acct_dict,
             slot=self._get_slot(block),
+            id=get_ctx(),
         )
         resp: EmulNeonCallResp = await self._call_method(self._emulate_neon_call, req, EmulNeonCallResp)
         if check_result:
@@ -250,6 +251,7 @@ class CoreApiClient(SimpleAppDataClient):
             verify=False,
             blockhash=blockhash.to_bytes(),
             tx_list=tuple(map(lambda tx: tx.to_bytes(), tx_list)),
+            id=get_ctx(),
         )
 
         resp: EmulSolTxListResp = await self._call_method(self._emulate_sol_tx_list, req, EmulSolTxListResp)

--- a/common/neon_rpc/server.py
+++ b/common/neon_rpc/server.py
@@ -68,6 +68,8 @@ class _Server:
             EVM_LOADER=str(NeonProg.ID),
             NEON_DB_CLICKHOUSE_URLS=";".join(self._cfg.ch_dsn_list),
             SOLANA_KEY_FOR_CONFIG=self._cfg.sol_key_for_evm_cfg.to_string(),
+            SOLANA_TEST_ACCOUNTS_INDEX_MEMORY_LIMIT_MB="value",  # This needs to be set in order to disable disk
+            # storage for AccountsDb when running Solana Bank Emulator
         )
 
         env = dict(os.environ)

--- a/common/neon_rpc/server.py
+++ b/common/neon_rpc/server.py
@@ -70,6 +70,7 @@ class _Server:
             SOLANA_KEY_FOR_CONFIG=self._cfg.sol_key_for_evm_cfg.to_string(),
             SOLANA_TEST_ACCOUNTS_INDEX_MEMORY_LIMIT_MB="value",  # This needs to be set in order to disable disk
             # storage for AccountsDb when running Solana Bank Emulator
+            SOLANA_RAYON_THREADS="1",
         )
 
         env = dict(os.environ)

--- a/common/utils/json_logger.py
+++ b/common/utils/json_logger.py
@@ -168,6 +168,10 @@ class JSONFormatter(logging.Formatter):
 _LOG_CTX = contextvars.ContextVar("log_context", default=dict())
 
 
+def get_ctx() -> str:
+    _LOG_CTX.get().get("ctx", "")
+
+
 class ContextFilter(Filter):
     def filter(self, record: LogRecord) -> bool:
         record.context = _LOG_CTX.get()


### PR DESCRIPTION
- Fixed neon-api OutOfMemory errors, caused by mmap failures in Solana Bank Emulator.
- Added ctx as id for neon-api requests for log correlation while debugging.