### PR TITLE
Support of the rollup in the proxy

### DIFF
--- a/common/config/constants.py
+++ b/common/config/constants.py
@@ -38,10 +38,10 @@ DEVNET_GENESIS_HASH: Final[str] = "4GoSwc9RDGduTDCLUgrHSEdMA5iMcigMfXkLEozNB8pX"
 DEVNET_GENESIS_TIME: Final[int] = 1647021674
 
 ROLLUP_PROGRAM_ID: Final[SolPubKey] = SolPubKey.from_raw("EgbRZxFRQTiZpQGinE5jT6KQq5jtVnjtLdSTkW5UTcAv")
-# TODO: specify block number when evm was deployed on the rollup.
-ROLLUP_GENESIS_HASH: Final[str] = "<block-hash-of-the-rollup-evm-deployed-on-the-rollup-network>"
-# TODO: specify genesis timestamp.
-ROLLUP_GENESIS_TIME: Final[int] = 133713371337
+# TODO: specify real block number when evm was deployed on the rollup.
+ROLLUP_GENESIS_HASH: Final[str] = os.environ.get("ROLLUP_GENESIS_HASH", "UNSPECIFIED_ROLLUP_GENESIS_HASH")
+# TODO: specify genesis timestamp once deployed.
+ROLLUP_GENESIS_TIME: Final[int] = int(os.environ.get("ROLLUP_GENESIS_TIME", "0"))
 
 UNKNOWN_GENESIS_HASH: Final[str] = "JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWcmM"  # Fake 0xFFFF..0000
 
@@ -57,9 +57,7 @@ NEON_PROXY_PKG_VER = f"Neon-Proxy/{NEON_PROXY_VER}"
 # Sanity check - make sure that CB settings are defaults if PROGRAM_ID is not rollup (so it's not changed by mistake).
 def _validate() -> None:
     if NEON_EVM_PROGRAM_ID == ROLLUP_PROGRAM_ID:
-        # TODO: remove it once ROLLUP GENESIS_HASH and GENESIS_TIME are valid.
-        raise ValueError("Rollup settings are not yet ready")
-
+        return
     # If not rollup, solana mainnet defaults should be used.
     if (
         SOLANA_MAX_HEAP_SIZE != _DEF_SOLANA_MAX_HEAP_SIZE

--- a/common/config/constants.py
+++ b/common/config/constants.py
@@ -4,9 +4,25 @@ from typing import Final
 from ..solana.pubkey import SolPubKey
 from ..solana.transaction import SOL_PACKET_SIZE as _SOL_PKT_SIZE
 
+######################################
+# Solana general settings:
 ONE_BLOCK_SEC: Final[float] = float(os.environ.get("SOLANA_BLOCK_SEC", "0.4"))
 MIN_FINALIZE_SEC: Final[float] = ONE_BLOCK_SEC * 32
 SOL_PACKET_SIZE: Final[int] = _SOL_PKT_SIZE
+
+######################################
+# Solana CB settings:
+_DEF_SOLANA_MAX_HEAP_SIZE: Final[int] = 256 * 1024
+SOLANA_MAX_HEAP_SIZE: Final[int] = int(os.environ.get("SOLANA_MAX_HEAP_SIZE", str(_DEF_SOLANA_MAX_HEAP_SIZE)))
+
+_DEF_SOLANA_MAX_CU_LIMIT: Final[int] = 1_400_000
+SOLANA_MAX_CU_LIMIT: Final[int] = int(os.environ.get("SOLANA_MAX_CU_LIMIT", str(_DEF_SOLANA_MAX_CU_LIMIT)))
+
+_DEF_SOLANA_DEFAULT_CU_LIMIT: Final[int] = 200_000
+SOLANA_DEFAULT_CU_LIMIT: Final[int] = int(os.environ.get("SOLANA_DEFAULT_CU_LIMIT", str(_DEF_SOLANA_DEFAULT_CU_LIMIT)))
+
+######################################
+# Neon settings:
 NEON_EVM_PROGRAM_ID: Final[SolPubKey] = SolPubKey.from_raw(
     os.environ.get("NEON_EVM_PROGRAM", os.environ.get("EVM_LOADER"))  # EVM_LOADER for compatibility only
 )
@@ -18,8 +34,14 @@ MAINNET_GENESIS_HASH: Final[str] = "7f1vrAJpnAFdqwNZQe8Z4pEnJjGDMeQqPWQ9Xf198byy
 MAINNET_GENESIS_TIME: Final[int] = 1684768103
 
 DEVNET_PROGRAM_ID: Final[SolPubKey] = SolPubKey.from_raw("eeLSJgWzzxrqKv1UxtRVVH8FX3qCQWUs9QuAjJpETGU")
-DEVNET_GENESIS_HASH: Final[str] = "4GoSwc9RDGduTDCLUgrHSEdMA5iMcigMfXkLEozNB8pX"   # 120'292'196
+DEVNET_GENESIS_HASH: Final[str] = "4GoSwc9RDGduTDCLUgrHSEdMA5iMcigMfXkLEozNB8pX"  # 120'292'196
 DEVNET_GENESIS_TIME: Final[int] = 1647021674
+
+ROLLUP_PROGRAM_ID: Final[SolPubKey] = SolPubKey.from_raw("EgbRZxFRQTiZpQGinE5jT6KQq5jtVnjtLdSTkW5UTcAv")
+# TODO: specify block number when evm was deployed on the rollup.
+ROLLUP_GENESIS_HASH: Final[str] = "<block-hash-of-the-rollup-evm-deployed-on-the-rollup-network>"
+# TODO: specify genesis timestamp.
+ROLLUP_GENESIS_TIME: Final[int] = 133713371337
 
 UNKNOWN_GENESIS_HASH: Final[str] = "JEKNVnkbo3jma5nREBBJCDoXFVeKkD56V3xKrvRmWcmM"  # Fake 0xFFFF..0000
 
@@ -30,3 +52,21 @@ _REVISION = "dev-NEON_PROXY_REVISION_TO_BE_REPLACED"
 NEON_PROXY_VER = f"v{_MAJOR_VER}.{_MINOR_VER}.{_BUILD_VER}-{_REVISION}"
 
 NEON_PROXY_PKG_VER = f"Neon-Proxy/{NEON_PROXY_VER}"
+
+
+# Sanity check - make sure that CB settings are defaults if PROGRAM_ID is not rollup (so it's not changed by mistake).
+def _validate() -> None:
+    if NEON_EVM_PROGRAM_ID == ROLLUP_PROGRAM_ID:
+        # TODO: remove it once ROLLUP GENESIS_HASH and GENESIS_TIME are valid.
+        raise ValueError("Rollup settings are not yet ready")
+
+    # If not rollup, solana mainnet defaults should be used.
+    if (
+        SOLANA_MAX_HEAP_SIZE != _DEF_SOLANA_MAX_HEAP_SIZE
+        or SOLANA_MAX_CU_LIMIT != _DEF_SOLANA_MAX_CU_LIMIT
+        or SOLANA_DEFAULT_CU_LIMIT != _DEF_SOLANA_DEFAULT_CU_LIMIT
+    ):
+        raise ValueError("Incorrect CB settings. Default CB Solana settings should be used for anything but rollup.")
+
+
+_validate()

--- a/common/solana/cb_program.py
+++ b/common/solana/cb_program.py
@@ -3,6 +3,8 @@ from typing import Final
 
 import solders.compute_budget as _cb
 
+from ..config.constants import SOLANA_DEFAULT_CU_LIMIT, SOLANA_MAX_CU_LIMIT, SOLANA_MAX_HEAP_SIZE
+
 from .instruction import SolTxIx
 from .pubkey import SolPubKey
 
@@ -15,9 +17,9 @@ class SolCuIxCode(IntEnum):
 
 class SolCbProg:
     ID: Final[SolPubKey] = SolPubKey.from_raw(_cb.ID)
-    MaxCuLimit: Final[int] = 1_400_000
-    DefCuLimit: Final[int] = 200_000
-    MaxHeapSize: Final[int] = 256 * 1024
+    MaxCuLimit: Final[int] = SOLANA_MAX_CU_LIMIT
+    DefCuLimit: Final[int] = SOLANA_DEFAULT_CU_LIMIT
+    MaxHeapSize: Final[int] = SOLANA_MAX_HEAP_SIZE
 
     @classmethod
     def make_heap_size_ix(cls, size: int) -> SolTxIx:

--- a/proxy/rpc/server_abc.py
+++ b/proxy/rpc/server_abc.py
@@ -14,6 +14,9 @@ from common.config.constants import (
     DEVNET_PROGRAM_ID,
     DEVNET_GENESIS_HASH,
     DEVNET_GENESIS_TIME,
+    ROLLUP_PROGRAM_ID,
+    ROLLUP_GENESIS_HASH,
+    ROLLUP_GENESIS_TIME,
     UNKNOWN_GENESIS_HASH,
 )
 from common.ethereum.commit_level import EthCommit
@@ -122,6 +125,9 @@ class NeonProxyAbc(BaseRpcServerAbc, abc.ABC):
         elif NeonProg.ID == DEVNET_PROGRAM_ID:
             block_hash = EthBlockHash.from_raw(base58.b58decode(DEVNET_GENESIS_HASH))
             block_time = DEVNET_GENESIS_TIME
+        elif NeonProg.ID == ROLLUP_PROGRAM_ID:
+            block_hash = EthBlockHash.from_raw(base58.b58decode(ROLLUP_GENESIS_HASH))
+            block_time = ROLLUP_GENESIS_TIME
         else:
             block = await self._sol_client.get_block(0, SolCommit.Confirmed)
             if block.is_empty:


### PR DESCRIPTION
1. Add separate network settings: program_id as specified in the EVM rollup config, genesis hash and time (TODO: specify when EVM is deployed).
2. Add Compute Budget env knobs for the rollup: max heap size, max cu limit, default cu limit.
3. Some validation: 
  - ensure that the Compute Budget settings are set to default in case network is not rollup
  - ensure that rollup proxy can't be run yet, we have to specify genesis params. 