### PR TITLE
NDEV-3464 remove Legacy flag from Account model

### DIFF
--- a/common/neon_rpc/api.py
+++ b/common/neon_rpc/api.py
@@ -643,7 +643,6 @@ EmulNeonCallExitCodeField = Annotated[EmulNeonCallExitCode, PlainValidator(EmulN
 class EmulAccountMetaModel(_BaseRespModel):
     pubkey: SolPubKeyField
     is_writable: bool
-    is_legacy: bool
 
     def to_sol_account_meta(self) -> SolAccountMeta:
         return SolAccountMeta(pubkey=self.pubkey, is_writable=self.is_writable, is_signer=False)

--- a/proxy/rpc/np_call_api.py
+++ b/proxy/rpc/np_call_api.py
@@ -55,7 +55,6 @@ class _RpcEthStateRequest(RootModel):
 class _RpcSolanaAccountModel(BaseJsonRpcModel):
     pubkey: SolPubKeyField
     isWritable: bool
-    isLegacy: bool
 
     @classmethod
     def from_raw(cls, raw: _RpcSolanaAccountModel | EmulAccountMetaModel | None) -> Self | None:
@@ -64,7 +63,7 @@ class _RpcSolanaAccountModel(BaseJsonRpcModel):
         elif isinstance(raw, _RpcSolanaAccountModel):
             return raw
         elif isinstance(raw, EmulAccountMetaModel):
-            return cls(pubkey=raw.pubkey, isWritable=raw.is_writable, isLegacy=False)
+            return cls(pubkey=raw.pubkey, isWritable=raw.is_writable)
         raise ValueError(f"Wrong input type: {type(raw).__name__}")
 
 

--- a/proxy/rpc/np_call_api.py
+++ b/proxy/rpc/np_call_api.py
@@ -64,7 +64,7 @@ class _RpcSolanaAccountModel(BaseJsonRpcModel):
         elif isinstance(raw, _RpcSolanaAccountModel):
             return raw
         elif isinstance(raw, EmulAccountMetaModel):
-            return cls(pubkey=raw.pubkey, isWritable=raw.is_writable, isLegacy=raw.is_legacy)
+            return cls(pubkey=raw.pubkey, isWritable=raw.is_writable, isLegacy=False)
         raise ValueError(f"Wrong input type: {type(raw).__name__}")
 
 


### PR DESCRIPTION
We removed legacy accounts support from EVM:  https://github.com/neonlabsorg/neon-evm/pull/630

So, we should remove appropriate fields from RPC validators too
